### PR TITLE
Update Mantine plugin to v6 and fix #6

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "gatsby": "^4.13.1",
-    "gatsby-plugin-mantine": "5.0.0",
+    "gatsby-plugin-mantine": "6.0.0",
     "typescript": "^4.6.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "start": "gatsby develop -H 0.0.0.0 -p 5001",
     "serve": "gatsby serve -H 0.0.0.0 -p 5002"
   },
+  "resolutions": {
+    "@mantine/styles": "^6.0.0"
+  },
   "dependencies": {
     "@emotion/react": "^11.9.3",
     "@mantine/core": "6.0.0",


### PR DESCRIPTION
The first commit updates Mantine plugin to v6. I opened another [PR with update](https://github.com/mantinedev/gatsby-plugin-mantine/pull/2) in the plugin repo.

The second commit fixes #6: without resolutions multiple copies of @mantine/styles
get installed and during SSR it creates another instance of Emotion
cache which is empty.